### PR TITLE
Add memory dump and simulated read fail

### DIFF
--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -1,18 +1,18 @@
 use std::{cmp::Ordering, collections::HashSet};
 
-use crate::{executor::trace::*, executor::alignment_masks::*, loader::program::*, ExecutionResult};
+use crate::{executor::trace::*, executor::alignment_masks::*, loader::program::*, ExecutionResult, REGISTERS_BASE_ADDRESS};
 use bitcoin_script_riscv::riscv::instruction_mapping::create_verification_script_mapping;
 use riscv_decode::{types::*, Instruction::{self, *}};
 use sha2::{Digest, Sha256};
-use super::{trace::TraceRWStep, validator::validate};
+use super::{trace::TraceRWStep, validator::validate, utils::{FailRead, FailReads}};
 
-
-pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &str, little_endian: bool, save_checkpoints: bool, limit_step: Option<u64>, print_trace: bool, 
-    validate_on_chain: bool, use_instruction_mapping: bool, print_program_stdout: bool, debug: bool, no_hash: bool,
-    fail_hash: Option<u64>, fail_execute: Option<u64>, trace_list: Option<Vec<u64>> ) -> Result<(Vec<String>, ExecutionResult), ExecutionResult> {
-
+pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &str, little_endian: bool, save_checkpoints: bool, limit_step: Option<u64>, print_trace: bool,
+                       validate_on_chain: bool, use_instruction_mapping: bool, print_program_stdout: bool, debug: bool, no_hash: bool,
+                       fail_hash: Option<u64>, fail_execute: Option<u64>, trace_list: Option<Vec<u64>>,
+                       fail_reads: Option<FailReads>) -> Result<(Vec<String>, ExecutionResult), ExecutionResult> {
     let trace_set: Option<HashSet<u64>> = trace_list.map(|vec| vec.into_iter().collect());
 
+    // todo(fede) can we remove this comment?
     //TOOD: This is a hack to copy the input into the bss section
     //copy into bss section the input
     if !input.is_empty() {
@@ -36,6 +36,11 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
     }
 
     let ret = loop {
+        let mut should_patch = (false, false);
+        if let Some(fr) = &fail_reads {
+            should_patch = fr.patch_mem(program); // patches memory only at the right step
+        }
+
         let mut trace = execute_step(program, print_program_stdout, debug);
 
         if trace.is_err() {
@@ -55,7 +60,10 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
         }
 
         if trace.is_ok() {
-            
+            if let Some(fr) = &fail_reads {
+                fr.patch_trace_reads(program.step, trace.as_mut().unwrap(), should_patch); // patches trace reads only at the right step
+            }
+
             if let Some(fail) = fail_execute {
                 if fail == program.step {
                     let value = &mut trace.as_mut().unwrap().trace_step.write_1.value;
@@ -144,6 +152,7 @@ pub fn wrapping_add_stype(value: u32, x: &SType) -> u32 {
 pub fn execute_step(program: &mut Program, print_program_stdout: bool, debug: bool) -> Result<TraceRWStep, ExecutionResult> {
     let pc = program.pc.clone();
 
+    println!("fetch opcode from memory");
     let opcode = program.read_mem(pc.get_address());
     let instruction = riscv_decode::decode(opcode).unwrap();
 

--- a/emulator/src/executor/mod.rs
+++ b/emulator/src/executor/mod.rs
@@ -2,3 +2,4 @@ pub mod trace;
 pub mod fetcher;
 pub mod alignment_masks;
 pub mod validator;
+pub mod utils;

--- a/emulator/src/executor/utils.rs
+++ b/emulator/src/executor/utils.rs
@@ -1,0 +1,160 @@
+use crate::{loader::program::Program, ExecutionResult};
+
+use super::trace::{TraceRWStep, TraceRead};
+
+#[derive(Debug, Default)]
+pub struct FailRead {
+    pub address_original: u32,
+    pub value: u32,
+    pub modified_address: u32,
+    pub modified_last_step: u64,
+    pub step: u64,
+    pub init: bool,
+}
+
+impl FailRead {
+    #[allow(clippy::ptr_arg)]
+    pub fn new(args: &Vec<String>) -> Self {
+        Self {
+            step: args[0].parse::<u64>().expect("Invalid modified_last_step"),
+            address_original: args[1].parse::<u32>().expect("Invalid address_original value"),
+            value: args[2].parse::<u32>().expect("Invalid value"),
+            modified_address: args[3].parse::<u32>().expect("Invalid modified_address value"),
+            modified_last_step: args[4].parse::<u64>().expect("Invalid modified_last_step"),
+            init: true,
+        }
+    }
+
+    pub fn patch_trace_read(&self, trace: &mut TraceRead) {
+        trace.address = self.modified_address;
+        trace.last_step = self.modified_last_step;
+    }
+
+    pub fn patch_mem(&self, program: &mut Program) {
+        // wether the addr belongs to a section or to a register
+        // todo this will be changed when we consolidate sections and registers
+        if program.find_section(self.address_original).is_some() { 
+            program.write_mem(self.address_original, self.value);
+        } else {
+            let idx = program.registers.get_register_idx(self.address_original);
+            program.registers.set(idx, self.value, program.step);
+        }
+    }
+}
+
+pub struct FailReads {
+    read_1: FailRead,
+    read_2: FailRead,
+}
+
+impl FailReads {
+    pub fn new(fail_read_1_args: Option<&Vec<String>>, fail_read_2_args: Option<&Vec<String>>) -> Self {
+        Self { 
+            read_1: fail_read_1_args.map_or(FailRead::default(), FailRead::new),
+            read_2: fail_read_2_args.map_or(FailRead::default(), FailRead::new),
+        }
+    }
+
+    pub fn patch_mem(&self, program: &mut Program) -> (bool, bool) {
+        let (mut patch_1, mut patch_2) = (false, false);
+        if self.read_1.init && self.read_1.step == program.step {
+            self.read_1.patch_mem(program);
+            patch_1 = true;
+        }
+        if self.read_2.init && self.read_2.step == program.step {
+            self.read_2.patch_mem(program);
+            patch_2 = true;
+        }
+
+        (patch_1, patch_2)
+    }
+
+    pub fn patch_trace_reads(&self, step: u64, trace: &mut TraceRWStep, should_patch: (bool, bool)) {
+        if self.read_1.init && should_patch.0 {
+            self.read_1.patch_trace_read(&mut trace.read_1);
+        }
+
+        if self.read_2.init && should_patch.1 {
+            self.read_2.patch_trace_read(&mut trace.read_2);
+        }
+    }
+}
+
+#[cfg(test)]
+mod utils_tests {
+    use super::*;
+    use crate::loader::program::{Program, Section};
+
+    #[test]
+    fn test_fail_read_1_register_patch() {
+        let mut program = Program::new(0x1000, 0xF000_0000, 0xE000_0000);
+        let fail_read_1_args = vec![
+            "10".to_string(), "4026531900".to_string(), "5".to_string(), "4026531900".to_string(), "15".to_string(),
+        ];
+        let fail_reads = FailReads::new(Some(&fail_read_1_args), None);
+        program.step = 10;
+        fail_reads.patch_mem(&mut program);
+        let idx = program.registers.get_register_idx(4026531900);
+
+        assert_eq!(program.registers.get(idx), 5);
+    }
+
+    #[test]
+    fn test_fail_read_2_register_patch() {
+        let mut program = Program::new(0x1000, 0xF000_0000, 0xE000_0000);
+        let fail_read_2_args = vec![
+            "10".to_string(), "4026531904".to_string(), "6".to_string(), "4026531904".to_string(), "20".to_string(),
+        ];
+        let fail_reads = FailReads::new(None, Some(&fail_read_2_args));
+        program.step = 10;
+        fail_reads.patch_mem(&mut program);
+        let idx = program.registers.get_register_idx(4026531904);
+
+        assert_eq!(program.registers.get(idx), 6);
+    }
+
+    #[test]
+    fn test_fail_read_1_memory_patch() {
+        let mut program = Program::new(0x1000, 0xF000_0000, 0xE000_0000);
+        program.add_section(Section {
+            name: "test_section".to_string(),
+            data: vec![0; 4],
+            last_step: vec![0; 4],
+            start: 0x1000,
+            size: 16,
+            is_code: false,
+            initialized: true,
+        });
+        let fail_read_1_args = vec![
+            "10".to_string(), "4096".to_string(), "10".to_string(), "4096".to_string(), "15".to_string(),
+        ];
+        let fail_reads = FailReads::new(Some(&fail_read_1_args), None);
+        program.step = 10;
+        fail_reads.patch_mem(&mut program);
+
+        assert_eq!(program.read_mem(4096), 10);
+    }
+
+    #[test]
+    fn test_fail_read_2_memory_patch() {
+        let mut program = Program::new(0x1000, 0xF000_0000, 0xE000_0000);
+        program.add_section(Section {
+            name: "test_section".to_string(),
+            data: vec![0; 4],
+            last_step: vec![0; 4],
+            start: 0x1000,
+            size: 16,
+            is_code: false,
+            initialized: true,
+        });
+        let fail_read_2_args = vec![
+            "10".to_string(), "4100".to_string(), "11".to_string(), "4100".to_string(), "20".to_string(),
+        ];
+        let fail_reads = FailReads::new(None, Some(&fail_read_2_args));
+        program.step = 10;
+        fail_reads.patch_mem(&mut program);
+
+        assert_eq!(program.read_mem(4100), 11);
+    }
+}
+

--- a/emulator/src/executor/utils.rs
+++ b/emulator/src/executor/utils.rs
@@ -1,4 +1,4 @@
-use crate::{loader::program::Program, ExecutionResult};
+use crate::{loader::program::*, ExecutionResult};
 
 use super::trace::{TraceRWStep, TraceRead};
 
@@ -36,7 +36,7 @@ impl FailRead {
         if program.find_section(self.address_original).is_some() { 
             program.write_mem(self.address_original, self.value);
         } else {
-            let idx = program.registers.get_register_idx(self.address_original);
+            let idx = program.registers.get_original_idx(self.address_original);
             program.registers.set(idx, self.value, program.step);
         }
     }
@@ -94,7 +94,7 @@ mod utils_tests {
         let fail_reads = FailReads::new(Some(&fail_read_1_args), None);
         program.step = 10;
         fail_reads.patch_mem(&mut program);
-        let idx = program.registers.get_register_idx(4026531900);
+        let idx = program.registers.get_original_idx(4026531900);
 
         assert_eq!(program.registers.get(idx), 5);
     }
@@ -108,7 +108,7 @@ mod utils_tests {
         let fail_reads = FailReads::new(None, Some(&fail_read_2_args));
         program.step = 10;
         fail_reads.patch_mem(&mut program);
-        let idx = program.registers.get_register_idx(4026531904);
+        let idx = program.registers.get_original_idx(4026531904);
 
         assert_eq!(program.registers.get(idx), 6);
     }

--- a/emulator/src/main.rs
+++ b/emulator/src/main.rs
@@ -103,11 +103,11 @@ enum Commands {
         #[arg(long, value_name = "TraceList")]
         list: Option<String>,
 
-        /// Fail reading read_1 (from a REGISTER) at a given step
+        /// Fail reading read_1 at a given step
         #[arg(long, value_names = &["step", "address_original", "value", "modified_address", "modified_last_step"], num_args = 5)]
         fail_read_1: Option<Vec<String>>,
 
-        /// Fail reading read_2 (from a REGISTER) at a given step
+        /// Fail reading read_2 at a given step
         #[arg(long, value_names = &["step", "address_original", "value", "modified_address", "modified_last_step"], num_args = 5)]
         fail_read_2: Option<Vec<String>>,
 

--- a/emulator/src/main.rs
+++ b/emulator/src/main.rs
@@ -111,6 +111,9 @@ enum Commands {
         #[arg(long, value_names = &["step", "address_original", "value", "modified_address", "modified_last_step"], num_args = 5)]
         fail_read_2: Option<Vec<String>>,
 
+        /// Memory dump at given step
+        #[arg(short, long)]
+        dump_mem: Option<u64>,
     },
 
 }
@@ -134,7 +137,7 @@ fn main() -> Result<(), ExecutionResult> {
         Some(Commands::Execute { elf, step, limit, input, input_section,
             input_as_little, no_hash, trace, verify, no_mapping, stdout , debug, sections,
             checkpoints, fail_hash, fail_execute, list,
-            fail_read_1: fail_read_1_args, fail_read_2: fail_read_2_args }) => {
+            fail_read_1: fail_read_1_args, fail_read_2: fail_read_2_args, dump_mem }) => {
 
             if elf.is_none() && step.is_none() {
                 println!("To execute an elf file or a checkpoint step is required");
@@ -183,9 +186,10 @@ fn main() -> Result<(), ExecutionResult> {
                 None
             };
 
-            execute_program(&mut program, input, &input_section.clone().unwrap_or(".input".to_string()),*input_as_little,
-                checkpoints, *limit,*trace, *verify, !*no_mapping,
-                *stdout, *debug, *no_hash, *fail_hash, *fail_execute, numbers, fail_reads)?;
+            execute_program(&mut program, input, &input_section.clone().unwrap_or(".input".to_string()),
+                *input_as_little, checkpoints, *limit,*trace,
+                *verify, !*no_mapping, *stdout, *debug,
+                *no_hash, *fail_hash, *fail_execute, numbers, *dump_mem, fail_reads)?;
         },
         None => {
             println!("No command specified");

--- a/emulator/tests/compliance.rs
+++ b/emulator/tests/compliance.rs
@@ -4,7 +4,7 @@ use emulator::{executor::fetcher::execute_program, loader::program::load_elf, Ex
 fn verify_file(fname: &str, validate_on_chain: bool) -> Result<(Vec<String>, ExecutionResult), ExecutionResult> {
     let mut program = load_elf(&fname, false);
     println!("Execute program {}", fname);
-    execute_program(&mut program, Vec::new(), ".bss", false, false, None, false, validate_on_chain, false, false, true, true, None, None, None)
+    execute_program(&mut program, Vec::new(), ".bss", false, false, None, false, validate_on_chain, false, false, true, true, None, None, None, None)
 }
 
 

--- a/emulator/tests/compliance.rs
+++ b/emulator/tests/compliance.rs
@@ -4,7 +4,8 @@ use emulator::{executor::fetcher::execute_program, loader::program::load_elf, Ex
 fn verify_file(fname: &str, validate_on_chain: bool) -> Result<(Vec<String>, ExecutionResult), ExecutionResult> {
     let mut program = load_elf(&fname, false);
     println!("Execute program {}", fname);
-    execute_program(&mut program, Vec::new(), ".bss", false, false, None, false, validate_on_chain, false, false, true, true, None, None, None, None)
+    execute_program(&mut program, Vec::new(), ".bss", false, false, None, false, validate_on_chain,
+        false, false, true, true, None, None, None, None, None)
 }
 
 


### PR DESCRIPTION
## In this PR
- added a memory dump for a given step
  - `--dump-mem STEP`
  - dumps registers and program sections
  - filters zero addresses on program sections
- added a mechanism to simulate a read fail 
  - `--fail-read-1 STEP ADDR_ORIGINAL VALUE ADDR_MODIFIED MODIFIED_LAST_STEP`
  - `--fail-read-2 STEP ADDR_ORIGINAL VALUE ADDR_MODIFIED MODIFIED_LAST_STEP`

## Dumping memory example

 ```bash
❯ cargo run --release --bin emulator execute --elf docker-riscv32/test_input.elf --sections --input 00001234 --input-as-little --dump-mem 8      

Loading section: .text Start: 0x80000000 Size: 0x000001e4 Initialized: true Flags: 110 Type: 1
Loading section: .text._start Start: 0x800001e4 Size: 0x00000014 Initialized: true Flags: 110 Type: 1
Loading section: .data Start: 0x90000000 Size: 0x00000004 Initialized: true Flags: 11 Type: 1
Loading section: .bss Start: 0xa0000000 Size: 0x00001004 Initialized: false Flags: 11 Type: 1000
Loading section: .stack Start: 0xe0000000 Size: 0x00800000 Initialized: false Flags: 11 Type: 1000
Loading section: .input Start: 0xaa000000 Size: 0x00200000 Initialized: false Flags: 11 Type: 1000
Execute program docker-riscv32/test_input.elf with input: [0, 0, 18, 52]

========== Dumping memory at step: 8 ==========

------- Section: REGISTERS Start: 0xf0000000 Size: 0x00000088 -------

Reg(0): 0xf0000000 Value: 0x00000000
Reg(1): 0xf0000004 Value: 0x800001ec
Reg(2): 0xf0000008 Value: 0xe07fffd0
Reg(3): 0xf000000c Value: 0x00000000
Reg(4): 0xf0000010 Value: 0x00000000
Reg(5): 0xf0000014 Value: 0x00000000
Reg(6): 0xf0000018 Value: 0x00000000
Reg(7): 0xf000001c Value: 0x00000000
Reg(8): 0xf0000020 Value: 0xe0800000
Reg(9): 0xf0000024 Value: 0x00000000
Reg(10): 0xf0000028 Value: 0x00000000
Reg(11): 0xf000002c Value: 0x00000000
Reg(12): 0xf0000030 Value: 0x00000000
Reg(13): 0xf0000034 Value: 0x00000000
Reg(14): 0xf0000038 Value: 0x00000000
Reg(15): 0xf000003c Value: 0xaa000000
Reg(16): 0xf0000040 Value: 0x00000000
Reg(17): 0xf0000044 Value: 0x00000000
Reg(18): 0xf0000048 Value: 0x00000000
Reg(19): 0xf000004c Value: 0x00000000
Reg(20): 0xf0000050 Value: 0x00000000
Reg(21): 0xf0000054 Value: 0x00000000
Reg(22): 0xf0000058 Value: 0x00000000
Reg(23): 0xf000005c Value: 0x00000000
Reg(24): 0xf0000060 Value: 0x00000000
Reg(25): 0xf0000064 Value: 0x00000000
Reg(26): 0xf0000068 Value: 0x00000000
Reg(27): 0xf000006c Value: 0x00000000
Reg(28): 0xf0000070 Value: 0x00000000
Reg(29): 0xf0000074 Value: 0x00000000
Reg(30): 0xf0000078 Value: 0x00000000
Reg(31): 0xf000007c Value: 0x00000000
AUXReg(32): 0xf0000080 Value: 0x00000000
AUXReg(33): 0xf0000084 Value: 0x00000000

------- Section: .text Start: 0x80000000 Size: 0x000001e4 -------

Address: 0x80000000 Value: 0x63400506
Address: 0x80000004 Value: 0x63c60506
Address: 0x80000008 Value: 0x13860500
Address: 0x8000000c Value: 0x93050500
Address: 0x80000010 Value: 0x1305f0ff
Address: 0x80000014 Value: 0x630c0602
Address: 0x80000018 Value: 0x93061000
Address: 0x8000001c Value: 0x637ab600
Address: 0x80000020 Value: 0x6358c000
Address: 0x80000024 Value: 0x13161600
Address: 0x80000028 Value: 0x93961600
Address: 0x8000002c Value: 0xe36ab6fe
Address: 0x80000030 Value: 0x13050000
Address: 0x80000034 Value: 0x63e6c500
Address: 0x80000038 Value: 0xb385c540
Address: 0x8000003c Value: 0x3365d500
Address: 0x80000040 Value: 0x93d61600
Address: 0x80000044 Value: 0x13561600
Address: 0x80000048 Value: 0xe39606fe
Address: 0x8000004c Value: 0x67800000
Address: 0x80000050 Value: 0x93820000
Address: 0x80000054 Value: 0xeff05ffb
Address: 0x80000058 Value: 0x13850500
Address: 0x8000005c Value: 0x67800200
Address: 0x80000060 Value: 0x3305a040
Address: 0x80000064 Value: 0x6348b000
Address: 0x80000068 Value: 0xb305b040
Address: 0x8000006c Value: 0x6ff0dff9
Address: 0x80000070 Value: 0xb305b040
Address: 0x80000074 Value: 0x93820000
Address: 0x80000078 Value: 0xeff01ff9
Address: 0x8000007c Value: 0x3305a040
Address: 0x80000080 Value: 0x67800200
Address: 0x80000084 Value: 0x93820000
Address: 0x80000088 Value: 0x63ca0500
Address: 0x8000008c Value: 0x634c0500
Address: 0x80000090 Value: 0xeff09ff7
Address: 0x80000094 Value: 0x13850500
Address: 0x80000098 Value: 0x67800200
Address: 0x8000009c Value: 0xb305b040
Address: 0x800000a0 Value: 0xe35805fe
Address: 0x800000a4 Value: 0x3305a040
Address: 0x800000a8 Value: 0xeff01ff6
Address: 0x800000ac Value: 0x3305b040
Address: 0x800000b0 Value: 0x67800200
Address: 0x800000b4 Value: 0x130101fd
Address: 0x800000b8 Value: 0x23268102
Address: 0x800000bc Value: 0x13040103
Address: 0x800000c0 Value: 0x232ea4fc
Address: 0x800000c4 Value: 0x232cb4fc
Address: 0x800000c8 Value: 0x232604fe
Address: 0x800000cc Value: 0x6f008003
Address: 0x800000d0 Value: 0x8327c4fd
Address: 0x800000d4 Value: 0x93f71700
Address: 0x800000d8 Value: 0x638a0700
Address: 0x800000dc Value: 0x0327c4fe
Address: 0x800000e0 Value: 0x832784fd
Address: 0x800000e4 Value: 0xb307f700
Address: 0x800000e8 Value: 0x2326f4fe
Address: 0x800000ec Value: 0x8327c4fd
Address: 0x800000f0 Value: 0x93d71700
Address: 0x800000f4 Value: 0x232ef4fc
Address: 0x800000f8 Value: 0x832784fd
Address: 0x800000fc Value: 0x93971700
Address: 0x80000100 Value: 0x232cf4fc
Address: 0x80000104 Value: 0x8327c4fd
Address: 0x80000108 Value: 0xe39407fc
Address: 0x8000010c Value: 0x8327c4fe
Address: 0x80000110 Value: 0x13850700
Address: 0x80000114 Value: 0x0324c102
Address: 0x80000118 Value: 0x13010103
Address: 0x8000011c Value: 0x67800000
Address: 0x80000120 Value: 0x130101fd
Address: 0x80000124 Value: 0x23268102
Address: 0x80000128 Value: 0x13040103
Address: 0x8000012c Value: 0x232ea4fc
Address: 0x80000130 Value: 0x232cb4fc
Address: 0x80000134 Value: 0xb71700a0
Address: 0x80000138 Value: 0x2324f4fe
Address: 0x8000013c Value: 0x832784fe
Address: 0x80000140 Value: 0x93873700
Address: 0x80000144 Value: 0x2324f4fe
Address: 0x80000148 Value: 0x232604fe
Address: 0x8000014c Value: 0x6f000003
Address: 0x80000150 Value: 0x8327c4fe
Address: 0x80000154 Value: 0x0327c4fd
Address: 0x80000158 Value: 0xb307f700
Address: 0x8000015c Value: 0x03c70700
Address: 0x80000160 Value: 0x832784fe
Address: 0x80000164 Value: 0x2380e700
Address: 0x80000168 Value: 0x93084007
Address: 0x8000016c Value: 0x73000000
Address: 0x80000170 Value: 0x8327c4fe
Address: 0x80000174 Value: 0x93871700
Address: 0x80000178 Value: 0x2326f4fe
Address: 0x8000017c Value: 0x0327c4fe
Address: 0x80000180 Value: 0x832784fd
Address: 0x80000184 Value: 0xe346f7fc
Address: 0x80000188 Value: 0x13000000
Address: 0x8000018c Value: 0x13000000
Address: 0x80000190 Value: 0x0324c102
Address: 0x80000194 Value: 0x13010103
Address: 0x80000198 Value: 0x67800000
Address: 0x8000019c Value: 0x130101fd
Address: 0x800001a0 Value: 0x23268102
Address: 0x800001a4 Value: 0x13040103
Address: 0x800001a8 Value: 0x232ea4fc
Address: 0x800001ac Value: 0xb70700aa
Address: 0x800001b0 Value: 0x2326f4fe
Address: 0x800001b4 Value: 0x8327c4fe
Address: 0x800001b8 Value: 0x03a70700
Address: 0x800001bc Value: 0xb7170000
Address: 0x800001c0 Value: 0x93874723
Address: 0x800001c4 Value: 0x6306f700
Address: 0x800001c8 Value: 0x93071000
Address: 0x800001cc Value: 0x6f008000
Address: 0x800001d0 Value: 0x93070000
Address: 0x800001d4 Value: 0x13850700
Address: 0x800001d8 Value: 0x0324c102
Address: 0x800001dc Value: 0x13010103
Address: 0x800001e0 Value: 0x67800000

------- Section: .text._start Start: 0x800001e4 Size: 0x00000014 -------

Address: 0x800001e4 Value: 0x13050000
Address: 0x800001e8 Value: 0xeff05ffb
Address: 0x800001ec Value: 0x6f004000
Address: 0x800001f0 Value: 0x9308d005
Address: 0x800001f4 Value: 0x73000000

------- Section: .data Start: 0x90000000 Size: 0x00000004 -------

Address: 0x90000000 Value: 0xefbeadde

------- Skipping empty section: .bss -------

------- Section: .input Start: 0xaa000000 Size: 0x00200000 -------

Address: 0xaa000000 Value: 0x34120000

------- Section: .stack Start: 0xe0000000 Size: 0x00800000 -------

Address: 0xe07fffec Value: 0x000000aa

================================================

 ```
 
 ## Simulating a reading failure
 
- Fail read value 1

```bash
❯ cargo run --release --bin emulator execute --elf docker-riscv32/test_input.elf --sections --input 00001234 --input-as-little --trace --debug --fail-read-1 11 4026531900 1024 4026531918 13

Loading section: .text Start: 0x80000000 Size: 0x000001e4 Initialized: true Flags: 110 Type: 1
Loading section: .text._start Start: 0x800001e4 Size: 0x00000014 Initialized: true Flags: 110 Type: 1
Loading section: .data Start: 0x90000000 Size: 0x00000004 Initialized: true Flags: 11 Type: 1
Loading section: .bss Start: 0xa0000000 Size: 0x00001004 Initialized: false Flags: 11 Type: 1000
Loading section: .stack Start: 0xe0000000 Size: 0x00800000 Initialized: false Flags: 11 Type: 1000
Loading section: .input Start: 0xaa000000 Size: 0x00200000 Initialized: false Flags: 11 Type: 1000
Execute program docker-riscv32/test_input.elf with input: [0, 0, 18, 52]
Step: 0 PC: 0x800001e4:0 Opcode: 0x00000513 Instruction: Addi(IType(1299))
4026531840;0;4294967295;0;0;0;2147484132;0;1299;4026531880;0;2147484136;0;f000002800000000800001e800;6bd95324f4551e8a698d44b387de61fcf68a0493ad9bb05baa3014d0b89b249a
Step: 1 PC: 0x800001e8:0 Opcode: 0xfb5ff0ef Instruction: Jal(JType(4217368815))
0;0;0;0;0;0;2147484136;0;4217368815;4026531844;2147484140;2147484060;0;f0000004800001ec8000019c00;ec6e4d675fb8e63f6a9fdc2b0ea4ce194cacc0696d787589ad28f99035ee8b2c
Step: 2 PC: 0x8000019c:0 Opcode: 0xfd010113 Instruction: Addi(IType(4244701459))
4026531848;3766484992;4294967295;0;0;0;2147484060;0;4244701459;4026531848;3766484944;2147484064;0;f0000008e07fffd0800001a000;38b0a95891cd3c2bfc3df599a697b6c2a62636292845ef0a378787c5ecdec52f
Step: 3 PC: 0x800001a0:0 Opcode: 0x02812623 Instruction: Sw(SType(42018339))
4026531848;3766484944;2;4026531872;0;4294967295;2147484064;0;42018339;3766484988;0;2147484068;0;e07ffffc00000000800001a400;df2c8193b03586664aa915ef8b2f938cc6652524ea40c1f4f4dd2bac93803411
Step: 4 PC: 0x800001a4:0 Opcode: 0x03010413 Instruction: Addi(IType(50398227))
4026531848;3766484944;2;0;0;0;2147484068;0;50398227;4026531872;3766484992;2147484072;0;f0000020e0800000800001a800;d99be764d8a4d169d78aef1006a9a04347e1d4f9cf4af03f4fd9e96c69a0e00f
Step: 5 PC: 0x800001a8:0 Opcode: 0xfca42e23 Instruction: Sw(SType(4238618147))
4026531872;3766484992;4;4026531880;0;0;2147484072;0;4238618147;3766484956;0;2147484076;0;e07fffdc00000000800001ac00;dd1f588fd3c36581d1251545facc669f363066b4d49439699a6f9b7eb5439cef
Step: 6 PC: 0x800001ac:0 Opcode: 0xaa0007b7 Instruction: Lui(UType(2852128695))
0;0;0;0;0;0;2147484076;0;2852128695;4026531900;2852126720;2147484080;0;f000003caa000000800001b000;41e59b033ab4940080d5af23ae607502e647da08dc9f90c7a5faa57849a25443
Step: 7 PC: 0x800001b0:0 Opcode: 0xfef42623 Instruction: Sw(SType(4277413411))
4026531872;3766484992;4;4026531900;2852126720;6;2147484080;0;4277413411;3766484972;2852126720;2147484084;0;e07fffecaa000000800001b400;bdcdac6789c86543781b7641a05115356ecca3f0a2cbac84cb4276449e3f3a70
Step: 8 PC: 0x800001b4:0 Opcode: 0xfec42783 Instruction: Lw(IType(4274268035))
4026531872;3766484992;4;3766484972;2852126720;7;2147484084;0;4274268035;4026531900;2852126720;2147484088;0;f000003caa000000800001b800;2056f44863330d19584092aecbe2310291abef7067913ef97d8a068e2998e630
Step: 9 PC: 0x800001b8:0 Opcode: 0x0007a703 Instruction: Lw(IType(501507))
4026531900;2852126720;8;2852126720;4660;4294967295;2147484088;0;501507;4026531896;4660;2147484092;0;f000003800001234800001bc00;0d96eec21bc7cf3f17ff17e540078fdd8f221d3a078a683d10002ccb5da1bd6f
Step: 10 PC: 0x800001bc:0 Opcode: 0x000017b7 Instruction: Lui(UType(6071))
0;0;0;0;0;0;2147484092;0;6071;4026531900;4096;2147484096;0;f000003c00001000800001c000;f82064e1016d33871ba7ad0ca1babb4d874d5e6cfd59a940b6d2a8909b167dc0
Step: 11 PC: 0x800001c0:0 Opcode: 0x23478793 Instruction: Addi(IType(591890323))
4026531918;1024;13;0;0;0;2147484096;0;591890323;4026531900;1588;2147484100;0;f000003c00000634800001c400;18bd34f022a26d43d9d67fd372965eae61c148de02308dc6b2472d1c31f12069
Step: 12 PC: 0x800001c4:0 Opcode: 0x00f70663 Instruction: Beq(BType(16189027))
4026531896;4660;9;4026531900;1588;11;2147484100;0;16189027;0;0;2147484104;0;0000000000000000800001c800;5e438f74cb62ad47579890d7b1f5c6211205c19fa2796b3bac6f3f1aa75703b1
Step: 13 PC: 0x800001c8:0 Opcode: 0x00100793 Instruction: Addi(IType(1050515))
4026531840;0;4294967295;0;0;0;2147484104;0;1050515;4026531900;1;2147484108;0;f000003c00000001800001cc00;7f7350ee4b174e4b705c40946ae5688ab8a12fa4bad35e3ec21b3671ca480a88
Step: 14 PC: 0x800001cc:0 Opcode: 0x0080006f Instruction: Jal(JType(8388719))
0;0;0;0;0;0;2147484108;0;8388719;0;0;2147484116;0;0000000000000000800001d400;fd5174704c11c408993e6d08cca958c433b22f6a61b69aaa2593c0850fc023b5
Step: 15 PC: 0x800001d4:0 Opcode: 0x00078513 Instruction: Addi(IType(492819))
4026531900;1;13;0;0;0;2147484116;0;492819;4026531880;1;2147484120;0;f000002800000001800001d800;c0bfddfc751abd7bbb4383830a947f90afaf5daece7e4fa9880e0cf11079fbeb
Step: 16 PC: 0x800001d8:0 Opcode: 0x02c12403 Instruction: Lw(IType(46212099))
4026531848;3766484944;2;3766484988;0;3;2147484120;0;46212099;4026531872;0;2147484124;0;f000002000000000800001dc00;67164665ba5f962467612c3b0166f7d06812d65939a02965a53c679ed372ce9b
Step: 17 PC: 0x800001dc:0 Opcode: 0x03010113 Instruction: Addi(IType(50397459))
4026531848;3766484944;2;0;0;0;2147484124;0;50397459;4026531848;3766484992;2147484128;0;f0000008e0800000800001e000;0c0e4176b7add20bd056a00fad2851076fbf027662216069ec3ba45ec415c8b1
Step: 18 PC: 0x800001e0:0 Opcode: 0x00008067 Instruction: Jalr(IType(32871))
4026531844;2147484140;1;0;0;0;2147484128;0;32871;0;0;2147484140;0;0000000000000000800001ec00;18c55c1e527fcdbf146295dfc0925abe112110d699d65bef723c5f8bb60ea068
Step: 19 PC: 0x800001ec:0 Opcode: 0x0040006f Instruction: Jal(JType(4194415))
0;0;0;0;0;0;2147484140;0;4194415;0;0;2147484144;0;0000000000000000800001f000;9a4fce5bae5b52e588b9f783b85019fbd1493e8fb9d5a240f46266ab90b052a5
Step: 20 PC: 0x800001f0:0 Opcode: 0x05d00893 Instruction: Addi(IType(97519763))
4026531840;0;4294967295;0;0;0;2147484144;0;97519763;4026531908;93;2147484148;0;f00000440000005d800001f400;fbf0314fe3a94fcd9b2dd21fe3f88a50e026a4a8dd9f6b3af270b3a8a28f03b8
Step: 21 PC: 0x800001f4:0 Opcode: 0x00000073 Instruction: Ecall
Exit code: 0x00000001
Register 0: 0x00000000
Register 1: 0x800001ec
Register 2: 0xe0800000
Register 3: 0x00000000
Register 4: 0x00000000
Register 5: 0x00000000
Register 6: 0x00000000
Register 7: 0x00000000
Register 8: 0x00000000
Register 9: 0x00000000
Register 10: 0x00000001
Register 11: 0x00000000
Register 12: 0x00000000
Register 13: 0x00000000
Register 14: 0x00001234
Register 15: 0x00000001
Register 16: 0x00000000
Register 17: 0x0000005d
Register 18: 0x00000000
Register 19: 0x00000000
Register 20: 0x00000000
Register 21: 0x00000000
Register 22: 0x00000000
Register 23: 0x00000000
Register 24: 0x00000000
Register 25: 0x00000000
Register 26: 0x00000000
Register 27: 0x00000000
Register 28: 0x00000000
Register 29: 0x00000000
Register 30: 0x00000000
Register 31: 0x00000000
Total steps: 21 0x0000000000000015
Result: Err(Success(1))
Returned value from main(): 0x00000001
aa000000: 00001234
aa000004: 00000000
aa000008: 00000000
aa00000c: 00000000
aa000010: 00000000
aa000014: 00000000
aa000018: 00000000
aa00001c: 00000000
aa000020: 00000000
aa000024: 00000000
Last hash: fbf0314fe3a94fcd9b2dd21fe3f88a50e026a4a8dd9f6b3af270b3a8a28f03b8
```
- Fail read value 2

```bash
❯ cargo run --release --bin emulator execute --elf docker-riscv32/test_input.elf --sections --input 00001234 --input-as-little --trace --debug --fail-read-2 12 4026531900 1024 4026531904 15

Loading section: .text Start: 0x80000000 Size: 0x000001e4 Initialized: true Flags: 110 Type: 1
Loading section: .text._start Start: 0x800001e4 Size: 0x00000014 Initialized: true Flags: 110 Type: 1
Loading section: .data Start: 0x90000000 Size: 0x00000004 Initialized: true Flags: 11 Type: 1
Loading section: .bss Start: 0xa0000000 Size: 0x00001004 Initialized: false Flags: 11 Type: 1000
Loading section: .stack Start: 0xe0000000 Size: 0x00800000 Initialized: false Flags: 11 Type: 1000
Loading section: .input Start: 0xaa000000 Size: 0x00200000 Initialized: false Flags: 11 Type: 1000
Execute program docker-riscv32/test_input.elf with input: [0, 0, 18, 52]
Step: 0 PC: 0x800001e4:0 Opcode: 0x00000513 Instruction: Addi(IType(1299))
4026531840;0;4294967295;0;0;0;2147484132;0;1299;4026531880;0;2147484136;0;f000002800000000800001e800;6bd95324f4551e8a698d44b387de61fcf68a0493ad9bb05baa3014d0b89b249a
Step: 1 PC: 0x800001e8:0 Opcode: 0xfb5ff0ef Instruction: Jal(JType(4217368815))
0;0;0;0;0;0;2147484136;0;4217368815;4026531844;2147484140;2147484060;0;f0000004800001ec8000019c00;ec6e4d675fb8e63f6a9fdc2b0ea4ce194cacc0696d787589ad28f99035ee8b2c
Step: 2 PC: 0x8000019c:0 Opcode: 0xfd010113 Instruction: Addi(IType(4244701459))
4026531848;3766484992;4294967295;0;0;0;2147484060;0;4244701459;4026531848;3766484944;2147484064;0;f0000008e07fffd0800001a000;38b0a95891cd3c2bfc3df599a697b6c2a62636292845ef0a378787c5ecdec52f
Step: 3 PC: 0x800001a0:0 Opcode: 0x02812623 Instruction: Sw(SType(42018339))
4026531848;3766484944;2;4026531872;0;4294967295;2147484064;0;42018339;3766484988;0;2147484068;0;e07ffffc00000000800001a400;df2c8193b03586664aa915ef8b2f938cc6652524ea40c1f4f4dd2bac93803411
Step: 4 PC: 0x800001a4:0 Opcode: 0x03010413 Instruction: Addi(IType(50398227))
4026531848;3766484944;2;0;0;0;2147484068;0;50398227;4026531872;3766484992;2147484072;0;f0000020e0800000800001a800;d99be764d8a4d169d78aef1006a9a04347e1d4f9cf4af03f4fd9e96c69a0e00f
Step: 5 PC: 0x800001a8:0 Opcode: 0xfca42e23 Instruction: Sw(SType(4238618147))
4026531872;3766484992;4;4026531880;0;0;2147484072;0;4238618147;3766484956;0;2147484076;0;e07fffdc00000000800001ac00;dd1f588fd3c36581d1251545facc669f363066b4d49439699a6f9b7eb5439cef
Step: 6 PC: 0x800001ac:0 Opcode: 0xaa0007b7 Instruction: Lui(UType(2852128695))
0;0;0;0;0;0;2147484076;0;2852128695;4026531900;2852126720;2147484080;0;f000003caa000000800001b000;41e59b033ab4940080d5af23ae607502e647da08dc9f90c7a5faa57849a25443
Step: 7 PC: 0x800001b0:0 Opcode: 0xfef42623 Instruction: Sw(SType(4277413411))
4026531872;3766484992;4;4026531900;2852126720;6;2147484080;0;4277413411;3766484972;2852126720;2147484084;0;e07fffecaa000000800001b400;bdcdac6789c86543781b7641a05115356ecca3f0a2cbac84cb4276449e3f3a70
Step: 8 PC: 0x800001b4:0 Opcode: 0xfec42783 Instruction: Lw(IType(4274268035))
4026531872;3766484992;4;3766484972;2852126720;7;2147484084;0;4274268035;4026531900;2852126720;2147484088;0;f000003caa000000800001b800;2056f44863330d19584092aecbe2310291abef7067913ef97d8a068e2998e630
Step: 9 PC: 0x800001b8:0 Opcode: 0x0007a703 Instruction: Lw(IType(501507))
4026531900;2852126720;8;2852126720;4660;4294967295;2147484088;0;501507;4026531896;4660;2147484092;0;f000003800001234800001bc00;0d96eec21bc7cf3f17ff17e540078fdd8f221d3a078a683d10002ccb5da1bd6f
Step: 10 PC: 0x800001bc:0 Opcode: 0x000017b7 Instruction: Lui(UType(6071))
0;0;0;0;0;0;2147484092;0;6071;4026531900;4096;2147484096;0;f000003c00001000800001c000;f82064e1016d33871ba7ad0ca1babb4d874d5e6cfd59a940b6d2a8909b167dc0
Step: 11 PC: 0x800001c0:0 Opcode: 0x23478793 Instruction: Addi(IType(591890323))
4026531900;4096;10;0;0;0;2147484096;0;591890323;4026531900;4660;2147484100;0;f000003c00001234800001c400;0c4b3bac99091e51a7d5ef924f28a9ce5b0b7b2ad1f2fe44850803fbac1706d5
Step: 12 PC: 0x800001c4:0 Opcode: 0x00f70663 Instruction: Beq(BType(16189027))
4026531896;4660;9;4026531904;1024;15;2147484100;0;16189027;0;0;2147484104;0;0000000000000000800001c800;bcb9d61e9063efbce9a396fc3ff9098b692703aecc396a39f2a0fda929a024f0
Step: 13 PC: 0x800001c8:0 Opcode: 0x00100793 Instruction: Addi(IType(1050515))
4026531840;0;4294967295;0;0;0;2147484104;0;1050515;4026531900;1;2147484108;0;f000003c00000001800001cc00;59f730b59d68d7b4e96e629b5176cbca7d74a317f1f3a23dea912c668f71459f
Step: 14 PC: 0x800001cc:0 Opcode: 0x0080006f Instruction: Jal(JType(8388719))
0;0;0;0;0;0;2147484108;0;8388719;0;0;2147484116;0;0000000000000000800001d400;c9f32f13bbdefcf708069ed5f7ad08352062f29c400da665bfb0793a36b1c50f
Step: 15 PC: 0x800001d4:0 Opcode: 0x00078513 Instruction: Addi(IType(492819))
4026531900;1;13;0;0;0;2147484116;0;492819;4026531880;1;2147484120;0;f000002800000001800001d800;d6c69c96ea6ff4425b05ea624cdb509ba93ce6b23cfc002fbb91ace159e968f8
Step: 16 PC: 0x800001d8:0 Opcode: 0x02c12403 Instruction: Lw(IType(46212099))
4026531848;3766484944;2;3766484988;0;3;2147484120;0;46212099;4026531872;0;2147484124;0;f000002000000000800001dc00;b48344c0a54c96425c6775cf22f3b729e4e9e611270cf321afedaad94d1692b2
Step: 17 PC: 0x800001dc:0 Opcode: 0x03010113 Instruction: Addi(IType(50397459))
4026531848;3766484944;2;0;0;0;2147484124;0;50397459;4026531848;3766484992;2147484128;0;f0000008e0800000800001e000;1c0af1cccc570c592a3c22f66161a8502beefed5ff9c43f27a790a1486eb0231
Step: 18 PC: 0x800001e0:0 Opcode: 0x00008067 Instruction: Jalr(IType(32871))
4026531844;2147484140;1;0;0;0;2147484128;0;32871;0;0;2147484140;0;0000000000000000800001ec00;1b26743620493a9888a16cc9f0a53ae019a15d4c957f325d6fb1a747819d294b
Step: 19 PC: 0x800001ec:0 Opcode: 0x0040006f Instruction: Jal(JType(4194415))
0;0;0;0;0;0;2147484140;0;4194415;0;0;2147484144;0;0000000000000000800001f000;e3e5d7928cee3ed4331dbcc658d8e5175b2b3b2b3844feb79d99e45171843f51
Step: 20 PC: 0x800001f0:0 Opcode: 0x05d00893 Instruction: Addi(IType(97519763))
4026531840;0;4294967295;0;0;0;2147484144;0;97519763;4026531908;93;2147484148;0;f00000440000005d800001f400;bb15c349a01f64ca75b71065a463d9eb0ce70a4c0353f4db49d65eee1702a380
Step: 21 PC: 0x800001f4:0 Opcode: 0x00000073 Instruction: Ecall
Exit code: 0x00000001
Register 0: 0x00000000
Register 1: 0x800001ec
Register 2: 0xe0800000
Register 3: 0x00000000
Register 4: 0x00000000
Register 5: 0x00000000
Register 6: 0x00000000
Register 7: 0x00000000
Register 8: 0x00000000
Register 9: 0x00000000
Register 10: 0x00000001
Register 11: 0x00000000
Register 12: 0x00000000
Register 13: 0x00000000
Register 14: 0x00001234
Register 15: 0x00000001
Register 16: 0x00000000
Register 17: 0x0000005d
Register 18: 0x00000000
Register 19: 0x00000000
Register 20: 0x00000000
Register 21: 0x00000000
Register 22: 0x00000000
Register 23: 0x00000000
Register 24: 0x00000000
Register 25: 0x00000000
Register 26: 0x00000000
Register 27: 0x00000000
Register 28: 0x00000000
Register 29: 0x00000000
Register 30: 0x00000000
Register 31: 0x00000000
Total steps: 21 0x0000000000000015
Result: Err(Success(1))
Returned value from main(): 0x00000001
aa000000: 00001234
aa000004: 00000000
aa000008: 00000000
aa00000c: 00000000
aa000010: 00000000
aa000014: 00000000
aa000018: 00000000
aa00001c: 00000000
aa000020: 00000000
aa000024: 00000000
Last hash: bb15c349a01f64ca75b71065a463d9eb0ce70a4c0353f4db49d65eee1702a380

```

