### PR TITLE
Fail PC at a given step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Then when the binary search requires some specific step execute from the closest
 
 `cargo run --release --bin emulator -- execute  --step 150000000 --limit 180000000 --list "160000000,165000000,170000000" --trace`
 
+#### Memory dump 
+
+To generate a memory dump at a given step `--dump-mem [step]`. This will dump the memory state at the given step, excluding all the empty addresses.
+
 ### Generating failing cases:
 
 To emulate an error in the hash calculation and get a defective hash list, use `--fail-hash [step]`
@@ -77,6 +81,9 @@ To emulate an error in the hash calculation and get a defective hash list, use `
 
 To emulate an error in the execution, `--fail-execute [step]`. This will add 1 to the trace_write_value.
 
+To emulate an error in the program counter `--fail-pc [step]`. This will advance the program counter twice at the given step.
+
+To emulate an error in the read value 1 or 2 `--fail-read-1/2 [step addr_original value addr_modified last_step_modified]`. This writes the given value at the given address, producing a read failure for `addr_original`. You also have to specify `addr_modified` and `last_step_modified` which are workarounds (they don't produce any real change) to generate a trace with different read `address` and `last_step` . The only way to produce a real different trace is by providing a different `value`.
 
 ## Building a program
 To build your own programs follow the instructions in the [docker folder](https://github.com/FairgateLabs/bitvmx-docker-riscv32/blob/main/README.md)

--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -71,6 +71,12 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
                 }
             }
 
+            if let Some(fail) = fail_pc {
+                if fail == program.step {
+                    program.pc.next_address(); // makes next pc fail
+                }
+            }
+
             if !no_hash {
                 let trace_bytes = trace.as_ref().unwrap().trace_step.to_bytes();
                 program.hash = compute_step_hash(&mut hasher, &program.hash, &trace_bytes);
@@ -113,14 +119,6 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
             break trace.unwrap_err();
         }
 
-        // makes next pc fail (if needed)
-        if trace.is_ok() {
-            if let Some(fail) = fail_pc {
-                if fail == program.step {
-                    program.pc.next_address();
-                }
-            }
-        }
 
         if let Some(limit_step) = limit_step {
             if  limit_step == program.step {

--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -9,7 +9,8 @@ use super::{trace::TraceRWStep, validator::validate, utils::FailReads};
 pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &str, little_endian: bool, save_checkpoints: bool, limit_step: Option<u64>, print_trace: bool,
                        validate_on_chain: bool, use_instruction_mapping: bool, print_program_stdout: bool, debug: bool, no_hash: bool,
                        fail_hash: Option<u64>, fail_execute: Option<u64>, trace_list: Option<Vec<u64>>,
-                       mem_dump: Option<u64>, fail_reads: Option<FailReads>) -> Result<(Vec<String>, ExecutionResult), ExecutionResult> {
+                       mem_dump: Option<u64>, fail_reads: Option<FailReads>,
+                       fail_pc: Option<u64>) -> Result<(Vec<String>, ExecutionResult), ExecutionResult> {
     let trace_set: Option<HashSet<u64>> = trace_list.map(|vec| vec.into_iter().collect());
 
     //TOOD: This is a hack to copy the input into the bss section
@@ -110,6 +111,16 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
 
         if trace.is_err() {
             break trace.unwrap_err();
+        }
+
+        // makes next pc fail (if needed)
+        if trace.is_ok() {
+            if let Some(fail) = fail_pc {
+                if fail == program.step {
+                    println!("failing pc");
+                    program.pc.next_address();
+                }
+            }
         }
 
         if let Some(limit_step) = limit_step {

--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -117,7 +117,6 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
         if trace.is_ok() {
             if let Some(fail) = fail_pc {
                 if fail == program.step {
-                    println!("failing pc");
                     program.pc.next_address();
                 }
             }

--- a/emulator/src/main.rs
+++ b/emulator/src/main.rs
@@ -114,6 +114,11 @@ enum Commands {
         /// Memory dump at given step
         #[arg(short, long)]
         dump_mem: Option<u64>,
+
+        /// Fail while reading the pc at the given step
+        #[arg(long)]
+        fail_pc: Option<u64>,
+
     },
 
 }
@@ -137,7 +142,7 @@ fn main() -> Result<(), ExecutionResult> {
         Some(Commands::Execute { elf, step, limit, input, input_section,
             input_as_little, no_hash, trace, verify, no_mapping, stdout , debug, sections,
             checkpoints, fail_hash, fail_execute, list,
-            fail_read_1: fail_read_1_args, fail_read_2: fail_read_2_args, dump_mem }) => {
+            fail_read_1: fail_read_1_args, fail_read_2: fail_read_2_args, dump_mem, fail_pc }) => {
 
             if elf.is_none() && step.is_none() {
                 println!("To execute an elf file or a checkpoint step is required");
@@ -187,9 +192,10 @@ fn main() -> Result<(), ExecutionResult> {
             };
 
             execute_program(&mut program, input, &input_section.clone().unwrap_or(".input".to_string()),
-                *input_as_little, checkpoints, *limit,*trace,
-                *verify, !*no_mapping, *stdout, *debug,
-                *no_hash, *fail_hash, *fail_execute, numbers, *dump_mem, fail_reads)?;
+                            *input_as_little, checkpoints, *limit, *trace,
+                            *verify, !*no_mapping, *stdout, *debug,
+                            *no_hash, *fail_hash, *fail_execute, numbers, *dump_mem, fail_reads,
+                            *fail_pc)?;
         },
         None => {
             println!("No command specified");

--- a/emulator/tests/compliance.rs
+++ b/emulator/tests/compliance.rs
@@ -5,7 +5,8 @@ fn verify_file(fname: &str, validate_on_chain: bool) -> Result<(Vec<String>, Exe
     let mut program = load_elf(&fname, false);
     println!("Execute program {}", fname);
     execute_program(&mut program, Vec::new(), ".bss", false, false, None, false, validate_on_chain,
-        false, false, true, true, None, None, None, None, None)
+                    false, false, true, true, None, None, None, None, None,
+                    None)
 }
 
 


### PR DESCRIPTION
This PR:
- `--fail-pc [step]`
- introduces a mechanism to simulate failure on the program counter read at a given `step`
- advances PC twice at `step` - 1, simulating a wrong PC at the given `step`

Example: 
```bash
❯ cargo run --release --bin emulator execute --elf docker-riscv32/test_input.elf --sections --input 00001234 --input-as-little --trace

4026531840;0;4294967295;0;0;0;2147484132;0;1299;4026531880;0;2147484136;0;f000002800000000800001e800;6bd95324f4551e8a698d44b387de61fcf68a0493ad9bb05baa3014d0b89b249a
0;0;0;0;0;0;2147484136;0;4217368815;4026531844;2147484140;2147484060;0;f0000004800001ec8000019c00;ec6e4d675fb8e63f6a9fdc2b0ea4ce194cacc0696d787589ad28f99035ee8b2c
4026531848;3766484992;4294967295;0;0;0;2147484060;0;4244701459;4026531848;3766484944;2147484064;0;f0000008e07fffd0800001a000;38b0a95891cd3c2bfc3df599a697b6c2a62636292845ef0a378787c5ecdec52f
4026531848;3766484944;2;4026531872;0;4294967295;2147484064;0;42018339;3766484988;0;2147484068;0;e07ffffc00000000800001a400;df2c8193b03586664aa915ef8b2f938cc6652524ea40c1f4f4dd2bac93803411
4026531848;3766484944;2;0;0;0;2147484068;0;50398227;4026531872;3766484992;2147484072;0;f0000020e0800000800001a800;d99be764d8a4d169d78aef1006a9a04347e1d4f9cf4af03f4fd9e96c69a0e00f
4026531872;3766484992;4;4026531880;0;0;2147484072;0;4238618147;3766484956;0;2147484076;0;e07fffdc00000000800001ac00;dd1f588fd3c36581d1251545facc669f363066b4d49439699a6f9b7eb5439cef
0;0;0;0;0;0;2147484076;0;2852128695;4026531900;2852126720;2147484080;0;f000003caa000000800001b000;41e59b033ab4940080d5af23ae607502e647da08dc9f90c7a5faa57849a25443
4026531872;3766484992;4;4026531900;2852126720;6;2147484080;0;4277413411;3766484972;2852126720;2147484084;0;e07fffecaa000000800001b400;bdcdac6789c86543781b7641a05115356ecca3f0a2cbac84cb4276449e3f3a70
4026531872;3766484992;4;3766484972;2852126720;7;2147484084;0;4274268035;4026531900;2852126720;2147484088;0;f000003caa000000800001b800;2056f44863330d19584092aecbe2310291abef7067913ef97d8a068e2998e630
4026531900;2852126720;8;2852126720;4660;4294967295;2147484088;0;501507;4026531896;4660;2147484092;0;f000003800001234800001bc00;0d96eec21bc7cf3f17ff17e540078fdd8f221d3a078a683d10002ccb5da1bd6f
0;0;0;0;0;0;2147484092;0;6071;4026531900;4096;2147484096;0;f000003c00001000800001c000;f82064e1016d33871ba7ad0ca1babb4d874d5e6cfd59a940b6d2a8909b167dc0
4026531900;4096;10;0;0;0;2147484096;0;591890323;4026531900;4660;2147484100;0;f000003c00001234800001c400;0c4b3bac99091e51a7d5ef924f28a9ce5b0b7b2ad1f2fe44850803fbac1706d5
4026531896;4660;9;4026531900;4660;11;2147484100;0;16189027;0;0;2147484112;0;0000000000000000800001d000;b13b5511a0fe7a39dda41eb5e5fb1253147d791d8c6baa76fc3364eb59f8862d
4026531840;0;4294967295;0;0;0;2147484112;0;1939;4026531900;0;2147484116;0;f000003c00000000800001d400;1457dff6d42a74c49af45ff6ca56ecb310b0efae6683e9e2ff7d175404b1cb33
4026531900;0;13;0;0;0;2147484116;0;492819;4026531880;0;2147484120;0;f000002800000000800001d800;7465f8321674c7c357fadfcb41e146bfaaa6bae876a932d3eac9a007a714c6a2
4026531848;3766484944;2;3766484988;0;3;2147484120;0;46212099;4026531872;0;2147484124;0;f000002000000000800001dc00;78c23e97c43e57bc1245abf4345d977ec52d3f6b78235a116ada3f5c5446433c
4026531848;3766484944;2;0;0;0;2147484124;0;50397459;4026531848;3766484992;2147484128;0;f0000008e0800000800001e000;ccc91a257dcf2be31d806e91c3254ac3f4576f71532f5c00c38f2a0e202f9ffe
4026531844;2147484140;1;0;0;0;2147484128;0;32871;0;0;2147484140;0;0000000000000000800001ec00;68eaf2149e21ae81635eb72455938e0fb49bde93cf411cee4d9097c49967f4bf
0;0;0;0;0;0;2147484140;0;4194415;0;0;2147484144;0;0000000000000000800001f000;12fb119411e061d5930834e91511109c5f93863fbfb40b31e0637b999b4b0dfe
4026531840;0;4294967295;0;0;0;2147484144;0;97519763;4026531908;93;2147484148;0;f00000440000005d800001f400;ae1dccf45845fa8ef8793bee55d02c0608eb9a59099f86889e594bf45818613c
Exit code: 0x00000000

❯ cargo run --release --bin emulator execute --elf docker-riscv32/test_input.elf --sections --input 00001234 --input-as-little --trace --fail-pc 15

4026531840;0;4294967295;0;0;0;2147484132;0;1299;4026531880;0;2147484136;0;f000002800000000800001e800;6bd95324f4551e8a698d44b387de61fcf68a0493ad9bb05baa3014d0b89b249a
0;0;0;0;0;0;2147484136;0;4217368815;4026531844;2147484140;2147484060;0;f0000004800001ec8000019c00;ec6e4d675fb8e63f6a9fdc2b0ea4ce194cacc0696d787589ad28f99035ee8b2c
4026531848;3766484992;4294967295;0;0;0;2147484060;0;4244701459;4026531848;3766484944;2147484064;0;f0000008e07fffd0800001a000;38b0a95891cd3c2bfc3df599a697b6c2a62636292845ef0a378787c5ecdec52f
4026531848;3766484944;2;4026531872;0;4294967295;2147484064;0;42018339;3766484988;0;2147484068;0;e07ffffc00000000800001a400;df2c8193b03586664aa915ef8b2f938cc6652524ea40c1f4f4dd2bac93803411
4026531848;3766484944;2;0;0;0;2147484068;0;50398227;4026531872;3766484992;2147484072;0;f0000020e0800000800001a800;d99be764d8a4d169d78aef1006a9a04347e1d4f9cf4af03f4fd9e96c69a0e00f
4026531872;3766484992;4;4026531880;0;0;2147484072;0;4238618147;3766484956;0;2147484076;0;e07fffdc00000000800001ac00;dd1f588fd3c36581d1251545facc669f363066b4d49439699a6f9b7eb5439cef
0;0;0;0;0;0;2147484076;0;2852128695;4026531900;2852126720;2147484080;0;f000003caa000000800001b000;41e59b033ab4940080d5af23ae607502e647da08dc9f90c7a5faa57849a25443
4026531872;3766484992;4;4026531900;2852126720;6;2147484080;0;4277413411;3766484972;2852126720;2147484084;0;e07fffecaa000000800001b400;bdcdac6789c86543781b7641a05115356ecca3f0a2cbac84cb4276449e3f3a70
4026531872;3766484992;4;3766484972;2852126720;7;2147484084;0;4274268035;4026531900;2852126720;2147484088;0;f000003caa000000800001b800;2056f44863330d19584092aecbe2310291abef7067913ef97d8a068e2998e630
4026531900;2852126720;8;2852126720;4660;4294967295;2147484088;0;501507;4026531896;4660;2147484092;0;f000003800001234800001bc00;0d96eec21bc7cf3f17ff17e540078fdd8f221d3a078a683d10002ccb5da1bd6f
0;0;0;0;0;0;2147484092;0;6071;4026531900;4096;2147484096;0;f000003c00001000800001c000;f82064e1016d33871ba7ad0ca1babb4d874d5e6cfd59a940b6d2a8909b167dc0
4026531900;4096;10;0;0;0;2147484096;0;591890323;4026531900;4660;2147484100;0;f000003c00001234800001c400;0c4b3bac99091e51a7d5ef924f28a9ce5b0b7b2ad1f2fe44850803fbac1706d5
4026531896;4660;9;4026531900;4660;11;2147484100;0;16189027;0;0;2147484112;0;0000000000000000800001d000;b13b5511a0fe7a39dda41eb5e5fb1253147d791d8c6baa76fc3364eb59f8862d
4026531840;0;4294967295;0;0;0;2147484112;0;1939;4026531900;0;2147484116;0;f000003c00000000800001d400;1457dff6d42a74c49af45ff6ca56ecb310b0efae6683e9e2ff7d175404b1cb33
4026531900;0;13;0;0;0;2147484116;0;492819;4026531880;0;2147484120;0;f000002800000000800001d800;7465f8321674c7c357fadfcb41e146bfaaa6bae876a932d3eac9a007a714c6a2
4026531848;3766484944;2;0;0;0;2147484124;0;50397459;4026531848;3766484992;2147484128;0;f0000008e0800000800001e000;d181803a922aea9575abd78858b74cc7a3ec4545c65b2dbae387137dfd29c7dd
4026531844;2147484140;1;0;0;0;2147484128;0;32871;0;0;2147484140;0;0000000000000000800001ec00;2f1316d48a7dfacb30a55ae04bce1452f7a130685e33ef6539655fcf8a5c996b
0;0;0;0;0;0;2147484140;0;4194415;0;0;2147484144;0;0000000000000000800001f000;99d2f3af101091116ce177f33870b1cc57104f2244c72835102385d4f22021dd
4026531840;0;4294967295;0;0;0;2147484144;0;97519763;4026531908;93;2147484148;0;f00000440000005d800001f400;64a8bab5736faf1897949e6802b30193bcdb1e9395b67abfefa7ef103e85bec0
Exit code: 0x00000000
```

The first execution executes 20 steps, while the wrong (`--fail-pc 15`) execution executes 19, producing different hashes.