### PR TITLE
fix, fail_pc fails before executing step

### DIFF
--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -41,6 +41,12 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
             should_patch = fr.patch_mem(program); // patches memory only at the right step
         }
 
+        if let Some(fail) = fail_pc {
+            if fail == program.step {
+                program.pc.next_address(); // makes pc fail by advancing twice
+            }
+        }
+
         let mut trace = execute_step(program, print_program_stdout, debug);
 
         if trace.is_err() {
@@ -67,12 +73,6 @@ pub fn execute_program(program: &mut Program, input: Vec<u8>, input_section: &st
                 if fail == program.step {
                     let value = &mut trace.as_mut().unwrap().trace_step.write_1.value;
                     *value = value.wrapping_add(1);
-                }
-            }
-
-            if let Some(fail) = fail_pc {
-                if fail == program.step {
-                    program.pc.next_address(); // makes next pc fail
                 }
             }
 

--- a/emulator/src/loader/program.rs
+++ b/emulator/src/loader/program.rs
@@ -118,7 +118,6 @@ impl ProgramCounter {
         self.micro += 1;
     }
 
-
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Fixes `--fail-pc` mechanism, which produces a failure on the program counter at the given step. In the old version, the failure was produced by advancing the PC twice AFTER executing the previous step (ie for `--fail-pc 3`, it moves the PC twice after finishing step 2). This approach was ok for most cases but for the first step is not behaving as expected because it never meets the expected condition. To fix this I've moved the failure logic to be produced BEFORE executing the step.