### PR TITLE
Fix division instructions to comply with RISC-V spec (VMX-CPU-009)

### DIFF
--- a/bitcoin-script-riscv/src/riscv/script_utils.rs
+++ b/bitcoin-script-riscv/src/riscv/script_utils.rs
@@ -1752,6 +1752,7 @@ mod tests {
         test_division_aux(-100, -6, 16, -4, true);
 
         test_division_aux(100, 6, 16, 4, false);
+        test_division_aux(100, -1, -100, 0, true);
     }
 
     fn test_left_rotate_helper(value: u32, rotate: u32, expected: u32) {

--- a/emulator/src/decision/challenge.rs
+++ b/emulator/src/decision/challenge.rs
@@ -1850,29 +1850,4 @@ mod tests {
             ForceChallenge::No,
         );
     }
-
-    #[test]
-    fn test_challenge_wrong_division() {
-        init_trace();
-
-        let fail_args = vec!["13", "0xF000003C", "0x64", "0xF000003C"]
-            .iter()
-            .map(|x| x.to_string())
-            .collect::<Vec<String>>();
-        let fail_write = Some(FailConfiguration::new_fail_write(FailWrite::new(
-            &fail_args,
-        )));
-
-        test_challenge_aux(
-            "audit_02",
-            "audit_02.yaml",
-            0,
-            true, // final trace verification fails due to wrong div result
-            fail_write,
-            None,
-            true,
-            ForceCondition::No,
-            ForceChallenge::No,
-        );
-    }
 }

--- a/emulator/src/decision/challenge.rs
+++ b/emulator/src/decision/challenge.rs
@@ -1850,4 +1850,29 @@ mod tests {
             ForceChallenge::No,
         );
     }
+
+    #[test]
+    fn test_challenge_wrong_division() {
+        init_trace();
+
+        let fail_args = vec!["13", "0xF000003C", "0x64", "0xF000003C"]
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        let fail_write = Some(FailConfiguration::new_fail_write(FailWrite::new(
+            &fail_args,
+        )));
+
+        test_challenge_aux(
+            "audit_02",
+            "audit_02.yaml",
+            0,
+            true, // final trace verification fails due to wrong div result
+            fail_write,
+            None,
+            true,
+            ForceCondition::No,
+            ForceChallenge::No,
+        );
+    }
 }

--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -523,30 +523,30 @@ pub fn op_arithmetic(
     let value_2 = program.registers.get(x.rs2());
 
     let witness = match instruction {
-        Rem(_) => match value_2 {
-            0 => Some(0xFFFF_FFFF),
-            0xFFFF_FFFF => Some(value_1),
-            _ => Some((value_1 as i32 / value_2 as i32) as u32),
-        },
-        Div(_) => match value_2 {
-            0 => Some(value_1),
-            0xFFFF_FFFF => Some(0),
-            _ => Some((value_1 as i32 % value_2 as i32) as u32),
-        },
-        Remu(_) => {
+        Rem(_) => Some(match (value_1 as i32, value_2 as i32) {
+            (_, 0) => (-1 as i32) as u32,
+            (std::i32::MIN, -1) => std::i32::MIN as u32,
+            _ => (value_1 as i32 / value_2 as i32) as u32,
+        }),
+        Div(_) => Some(match (value_1 as i32, value_2 as i32) {
+            (_, 0) => value_1,
+            (std::i32::MIN, -1) => 0,
+            _ => (value_1 as i32 % value_2 as i32) as u32,
+        }),
+        Remu(_) => Some({
             if value_2 == 0 {
-                Some(0xFFFFFFFF)
+                std::i32::MAX as u32
             } else {
-                Some(value_1 / value_2)
+                value_1 / value_2
             }
-        }
-        Divu(_) => {
+        }),
+        Divu(_) => Some({
             if value_2 == 0 {
-                Some(value_1)
+                value_1
             } else {
-                Some(value_1 % value_2)
+                value_1 % value_2
             }
-        }
+        }),
         _ => None,
     };
 
@@ -567,21 +567,21 @@ pub fn op_arithmetic(
             let result: u64 = (value_1 as u64) * (value_2 as u64);
             (result >> 32) as u32 // High 32 bits
         }
-        Div(_) => match value_2 {
-            0 => 0xFFFF_FFFF,
-            0xFFFF_FFFF => value_1,
+        Div(_) => match (value_1 as i32, value_2 as i32) {
+            (_, 0) => (-1 as i32) as u32,
+            (std::i32::MIN, -1) => std::i32::MIN as u32,
             _ => (value_1 as i32 / value_2 as i32) as u32,
         },
         Divu(_) => {
             if value_2 == 0 {
-                0xFFFFFFFF
+                std::u32::MAX as u32
             } else {
                 value_1 / value_2
             }
         }
-        Rem(_) => match value_2 {
-            0 => value_1,
-            0xFFFF_FFFF => 0,
+        Rem(_) => match (value_1 as i32, value_2 as i32) {
+            (_, 0) => value_1,
+            (std::i32::MIN, -1) => 0,
             _ => (value_1 as i32 % value_2 as i32) as u32,
         },
         Remu(_) => {

--- a/emulator/src/executor/fetcher.rs
+++ b/emulator/src/executor/fetcher.rs
@@ -535,7 +535,7 @@ pub fn op_arithmetic(
         }),
         Remu(_) => Some({
             if value_2 == 0 {
-                std::i32::MAX as u32
+                std::u32::MAX
             } else {
                 value_1 / value_2
             }
@@ -574,7 +574,7 @@ pub fn op_arithmetic(
         },
         Divu(_) => {
             if value_2 == 0 {
-                std::u32::MAX as u32
+                std::u32::MAX
             } else {
                 value_1 / value_2
             }

--- a/emulator/tests/audit.rs
+++ b/emulator/tests/audit.rs
@@ -13,7 +13,7 @@ fn audit_tests() {
         if let Ok(path) = path {
             let fname = path.file_name();
             let fname = fname.to_string_lossy();
-            if fname.ends_with("verify.elf") {
+            if fname.ends_with("verify.elf") && fname.contains("09") {
                 let path = path.path();
                 let path = path.to_string_lossy();
 

--- a/emulator/tests/audit.rs
+++ b/emulator/tests/audit.rs
@@ -13,7 +13,7 @@ fn audit_tests() {
         if let Ok(path) = path {
             let fname = path.file_name();
             let fname = fname.to_string_lossy();
-            if fname.ends_with(".elf") && !fname.contains("audit_01") {
+            if fname.ends_with("verify.elf") {
                 let path = path.path();
                 let path = path.to_string_lossy();
 

--- a/emulator/tests/audit.rs
+++ b/emulator/tests/audit.rs
@@ -5,15 +5,15 @@ mod utils;
 use utils::common::verify_file;
 
 #[test]
-fn list_files() {
-    let path = "../docker-riscv32/compliance/build";
+fn audit_tests() {
+    let path = "../docker-riscv32/riscv32/build/audit";
     let paths = std::fs::read_dir(path).unwrap();
     let mut count = 0;
     for path in paths {
         if let Ok(path) = path {
             let fname = path.file_name();
             let fname = fname.to_string_lossy();
-            if fname.ends_with(".elf") && !fname.contains("fence_i") {
+            if fname.ends_with(".elf") && !fname.contains("audit_01") {
                 let path = path.path();
                 let path = path.to_string_lossy();
 
@@ -31,5 +31,5 @@ fn list_files() {
     }
 
     info!("Total files executed: {}", count);
-    assert_eq!(count, 47);
+    assert_eq!(count, 1);
 }

--- a/emulator/tests/test_r_type_instructions.rs
+++ b/emulator/tests/test_r_type_instructions.rs
@@ -237,4 +237,5 @@ pub fn test_division() {
     test_division_aux(-100, -6, 16, -4, true);
 
     test_division_aux(100, 6, 16, 4, false);
+    test_division_aux(100, -1, -100, 0, true);
 }

--- a/emulator/tests/utils/common.rs
+++ b/emulator/tests/utils/common.rs
@@ -104,5 +104,6 @@ pub fn verify_file(
         None,
         None,
         FailConfiguration::default(),
+        false,
     ))
 }

--- a/emulator/tests/utils/common.rs
+++ b/emulator/tests/utils/common.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 use bitvmx_cpu_definitions::{memory::SectionDefinition, trace::ProgramCounter};
-use emulator::loader::program::{Program, Registers, Section};
+use emulator::{executor::{fetcher::{execute_program, FullTrace}, utils::FailConfiguration}, loader::program::{load_elf, Program, Registers, Section}, EmulatorError, ExecutionResult};
 use rand::Rng;
 use riscv_decode::types::{BType, IType, JType, RType, SType, ShiftType, UType};
+use tracing::info;
 use std::ops::RangeInclusive;
 
 const PROGRAM_REG_RANGE: RangeInclusive<u32> = 0x1..=0x1F;
@@ -78,4 +79,30 @@ pub fn get_new_section() -> Section {
 pub fn rnd_range() -> u32 {
     let mut rng = rand::thread_rng();
     rng.gen_range(PROGRAM_REG_RANGE)
+}
+
+pub fn verify_file(
+    fname: &str,
+    verify_on_chain: bool,
+) -> Result<(ExecutionResult, FullTrace), EmulatorError> {
+    let mut program = load_elf(&fname, false)?;
+
+    info!("Execute program {}", fname);
+    Ok(execute_program(
+        &mut program,
+        Vec::new(),
+        ".bss",
+        false,
+        &None,
+        None,
+        false,
+        verify_on_chain,
+        false,
+        false,
+        false,
+        true,
+        None,
+        None,
+        FailConfiguration::default(),
+    ))
 }


### PR DESCRIPTION
The overflow condition was not correctly implemented. We assumed that dividing by -1 would be enough to trigger an overflow, but in reality, it only occurs when dividing `i32::MIN` by -1. This was not caught by the compliance test because the only instance of division by -1 was specifically used to test for overflows.

```asm
8000007c <test_7>:
8000007c:       00700193                li      gp,7
80000080:       800005b7                lui     a1,0x80000
80000084:       fff00613                li      a2,-1
80000088:       02c5d733                divu    a4,a1,a2
8000008c:       00000393                li      t2,0
80000090:       04771863                bne     a4,t2,800000e0 <fail>
```

The division by 0 worked correctly (note that for the divu case it says 2^{L}-1 and not -2^{L-1}), I just changed it a bit to be more explicit (eg, u32::MAX instead of 0xFFFF_FFFF)
<img width="1684" height="292" alt="image" src="https://github.com/user-attachments/assets/fcd3aacb-1d61-4195-b6a5-4745e85c90cf" />
