### PR TITLE
fix multiplication in bitcoin script (VMX-CPU-012, VMX-CPU-013)

### DIFF
--- a/bitcoin-script-riscv/src/riscv/script_utils.rs
+++ b/bitcoin-script-riscv/src/riscv/script_utils.rs
@@ -949,8 +949,8 @@ pub fn multiply(
 
     logic_table.drop(stack);
 
-    let modulo = modulo_table(stack, 128);
-    let quotient = quotient_table_ex(stack, 128);
+    let modulo = modulo_table(stack, 135);
+    let quotient = quotient_table_ex(stack, 135);
 
     for _ in 0..15 {
         stack.from_altstack();
@@ -1691,6 +1691,33 @@ mod tests {
         test_multiply_aux(0xFFFF_FFFF, 0xFFFF_FFFF, 0xFFFF_FFFE, 0x0000_0001);
         test_multiply_aux(0x0, 0xFFFF_FFFF, 0, 0);
         test_multiply_aux(0xFFFF_FFFF, 0x1, 0x0, 0xFFFF_FFFF);
+        test_multiply_aux(0x1B49_F21B, 0x1F51_E1ED, 0x0356_AECC, 0x20C9_DDFF);
+    }
+
+    fn test_mulh_aux(a: i32, b: i32, expected: i32) {
+        let mut stack = StackTracker::new();
+        let tables = StackTables::new(&mut stack, true, true, 0, 0, 0);
+
+
+        let a = stack.number_u32(a as u32);
+        let b = stack.number_u32(b as u32);
+
+        let result = mulh(&mut stack, &tables, a, b, false);
+
+        let expected = stack.number_u32(expected as u32);
+
+        stack.equals(result, true, expected, true);
+        tables.drop(&mut stack);
+
+        stack.op_true();
+
+        assert!(stack.run().success);
+    }
+
+    #[test]
+    fn test_mulh() {
+        test_mulh_aux(-0x7BDD_925D, -0x7F37_3DED, 0x3D8D_A62D);
+        test_mulh_aux(0x2A37_E15A, -0xC16_20C2, -0x1FE_44C5);
     }
 
     fn test_division_aux(

--- a/emulator/tests/audit.rs
+++ b/emulator/tests/audit.rs
@@ -13,7 +13,7 @@ fn audit_tests() {
         if let Ok(path) = path {
             let fname = path.file_name();
             let fname = fname.to_string_lossy();
-            if fname.ends_with("verify.elf") && fname.contains("09") {
+            if fname.ends_with("verify.elf") && (fname.contains("09") || fname.contains("12")) || fname.contains("13") {
                 let path = path.path();
                 let path = path.to_string_lossy();
 
@@ -31,5 +31,5 @@ fn audit_tests() {
     }
 
     info!("Total files executed: {}", count);
-    assert_eq!(count, 1);
+    assert_eq!(count, 3);
 }

--- a/emulator/tests/utils/common.rs
+++ b/emulator/tests/utils/common.rs
@@ -1,10 +1,17 @@
 #![allow(dead_code)]
 use bitvmx_cpu_definitions::{memory::SectionDefinition, trace::ProgramCounter};
-use emulator::{executor::{fetcher::{execute_program, FullTrace}, utils::FailConfiguration}, loader::program::{load_elf, Program, Registers, Section}, EmulatorError, ExecutionResult};
+use emulator::{
+    executor::{
+        fetcher::{execute_program, FullTrace},
+        utils::FailConfiguration,
+    },
+    loader::program::{load_elf, Program, Registers, Section},
+    EmulatorError, ExecutionResult,
+};
 use rand::Rng;
 use riscv_decode::types::{BType, IType, JType, RType, SType, ShiftType, UType};
-use tracing::info;
 use std::ops::RangeInclusive;
+use tracing::info;
 
 const PROGRAM_REG_RANGE: RangeInclusive<u32> = 0x1..=0x1F;
 


### PR DESCRIPTION
The modulo and quotient lookup tables were not large enough to cover the full range of values produced during multiplication. Intermediate results correctly ranged from 0 to 127, but after adding the quotient from division by 16 (maximum value 7), results could reach up to 134.

This caused `OP_PICK` to sometimes access data out of bounds, leading to one of two issues:

- An `InvalidStackOperation` error if the stack had insufficient elements.
- Incorrect results if unrelated values were present (e.g., in the mulh case).