### PR TITLE
op_load should fail even with rd = x0 (VMX-CPU-002)

### DIFF
--- a/bitcoin-script-riscv/src/riscv/instruction_mapping.rs
+++ b/bitcoin-script-riscv/src/riscv/instruction_mapping.rs
@@ -50,7 +50,7 @@ fn name_or_nop<X: RdZero>(x: &X, name: &str) -> String {
 }
 
 fn name_or_nop_with_micro<X: RdZero>(x: &X, name: &str, micro: u8) -> String {
-    if x.is_rd_zero() {
+    if micro > 1 && x.is_rd_zero() {
         "nop".to_string()
     } else {
         format!("{}_{}", name, micro)

--- a/bitcoin-script-riscv/src/riscv/instructions.rs
+++ b/bitcoin-script-riscv/src/riscv/instructions.rs
@@ -793,7 +793,7 @@ pub fn execute_step(
         )),
 
         Lh(x) | Lhu(x) | Lw(x) | Lbu(x) | Lb(x) => {
-            if x.rd() == 0 {
+            if micro > 1 && x.rd() == 0 {
                 Ok(op_nop(stack, trace_read))
             } else {
                 Ok(op_load(

--- a/emulator/src/decision/challenge.rs
+++ b/emulator/src/decision/challenge.rs
@@ -1357,4 +1357,76 @@ mod tests {
             ForceChallenge::No,
         );
     }
+
+    #[test]
+    fn test_challenge_load_to_x0_aligned() {
+        init_trace();
+
+        let fail_execute = FailExecute {
+            step: 9,
+            fake_trace: TraceRWStep::new(
+                9,
+                TraceRead::new(4026531900, 2852134912, 8),
+                TraceRead::new(2852134912, 0, LAST_STEP_INIT),
+                TraceReadPC::new(ProgramCounter::new(2147483796, 0), 499715),
+                TraceStep::new(TraceWrite::default(), ProgramCounter::new(2147483800, 0)),
+                None,
+                MemoryWitness::new(
+                    MemoryAccessType::Register,
+                    MemoryAccessType::Memory,
+                    MemoryAccessType::Unused,
+                ),
+            ),
+        };
+
+        let fail_execute = Some(FailConfiguration::new_fail_execute(fail_execute));
+
+        test_challenge_aux(
+            "audit_02_aligned",
+            "audit_02_aligned.yaml",
+            0,
+            false,
+            fail_execute,
+            None,
+            true,
+            ForceCondition::No,
+            ForceChallenge::No,
+        );
+    }
+
+    #[test]
+    fn test_challenge_load_to_x0_unaligned() {
+        init_trace();
+
+        let fail_execute = FailExecute {
+            step: 10,
+            fake_trace: TraceRWStep::new(
+                10,
+                TraceRead::new(4026531900, 2852134912, 8),
+                TraceRead::new(2852134912, 0, LAST_STEP_INIT),
+                TraceReadPC::new(ProgramCounter::new(2147483796, 1), 4292321283),
+                TraceStep::new(TraceWrite::new(4026531972, 0), ProgramCounter::new(2147483796, 2)),
+                None,
+                MemoryWitness::new(
+                    MemoryAccessType::Register,
+                    MemoryAccessType::Memory,
+                    MemoryAccessType::Register,
+                ),
+            ),
+        };
+
+        let fail_execute = Some(FailConfiguration::new_fail_execute(fail_execute));
+
+        test_challenge_aux(
+            "audit_02_unaligned",
+            "audit_02_unaligned.yaml",
+            0,
+            false,
+            fail_execute,
+            None,
+            true,
+            ForceCondition::No,
+            ForceChallenge::No,
+        );
+    }
 }


### PR DESCRIPTION
A load to x0 should not be a nop. If it access invalid memory it should fail, even if the value will be discarded. Since the failing reads will occur in the first two micro-instructions, we can run the next ones as nop if rd is x0.